### PR TITLE
Confluence 7.11.0 Java fatal error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN export CONTAINER_USER=confluence                        && \
             -s /bin/bash                                       \
             -S $CONTAINER_USER                                 \
     # glibc and pub key already installed by parent image; we need to install latest bin and i18n \
-    && export GLIBC_VERSION=2.29-r0                            \
+    && export GLIBC_VERSION=2.32-r0                            \
     && export GLIBC_DOWNLOAD_URL=https://github.com/sgerrand/alpine-pkg-glibc/releases/download/$GLIBC_VERSION \
     && export GLIBC_BIN=glibc-bin-$GLIBC_VERSION.apk           \
     && export GLIBC_I18N=glibc-i18n-$GLIBC_VERSION.apk         \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,8 @@ ARG LANG_COUNTRY=US
 # Setup useful environment variables
 ENV CONF_HOME=/var/atlassian/confluence \
     CONF_INSTALL=/opt/atlassian/confluence \
-    MYSQL_DRIVER_VERSION=5.1.47
+    MYSQL_DRIVER_VERSION=5.1.47 \
+    POSTGRESQL_DRIVER_VERSION=42.2.18
 
 # Install Atlassian Confluence
 RUN export CONTAINER_USER=confluence                        && \
@@ -80,6 +81,10 @@ RUN export CONTAINER_USER=confluence                        && \
       -C /tmp                                                                                                   && \
     cp /tmp/mysql-connector-java-${MYSQL_DRIVER_VERSION}/mysql-connector-java-${MYSQL_DRIVER_VERSION}-bin.jar      \
       ${CONF_INSTALL}/lib/mysql-connector-java-${MYSQL_DRIVER_VERSION}-bin.jar                                  && \
+    rm -f                                                                                                          \
+      ${CONF_INSTALL}/confluence/WEB-INF/lib/postgresql-*.jar                                                   && \
+    wget -O ${CONF_INSTALL}/confluence/WEB-INF/lib/postgresql-${POSTGRESQL_DRIVER_VERSION}.jar                     \
+      https://jdbc.postgresql.org/download/postgresql-${POSTGRESQL_DRIVER_VERSION}.jar                          && \
     chown -R confluence:confluence ${CONF_INSTALL}                                                              && \
     # Adding letsencrypt-ca to truststore
     export KEYSTORE=$JAVA_HOME/lib/security/cacerts                                                             && \


### PR DESCRIPTION
I just updated the confluence image to the newest version (7.11.0).
Right at startup the images crashed with the following message:
```
confluence_1           | # A fatal error has been detected by the Java Runtime Environment:
confluence_1           | #
confluence_1           | #  SIGSEGV (0xb) at pc=0x00007fd7ff071980, pid=8, tid=0x00007fd757bfd700
confluence_1           | #
confluence_1           | # JRE version: OpenJDK Runtime Environment (8.0_282-b08) (build 1.8.0_282-b08)
confluence_1           | # Java VM: OpenJDK 64-Bit Server VM (25.282-b08 mixed mode linux-amd64 compressed oops)
confluence_1           | # Problematic frame:
confluence_1           | # C  [libc.so.6+0x81980]  _IO_link_in+0x1f0
confluence_1           | #
confluence_1           | # Core dump written. Default location: /var/atlassian/confluence/core or core.8
confluence_1           | #
confluence_1           | # An error report file with more information is saved as:
confluence_1           | # /var/atlassian/confluence/hs_err_pid8.log
confluence_1           | # [ timer expired, abort... ]
```

I managed to solve the issue by updating the the glibc version to 2.32-r0. 
(2.33.-r0 was not possible due to missing version in libc.so.6)